### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const styles = css`
 
 function Button({ primary, color, className, ...props }) {
   return (
-    <div
+    <button
       {...props}
       className={classNames(
         className,


### PR DESCRIPTION
Update README.md to show that `styled('button')` actually returns a `<button>` element and not a `<div>`. (AFAIK that is what happens, haven't actually tried...)