### PR TITLE
Fix typo in Babel source type

### DIFF
--- a/src/traverse.js
+++ b/src/traverse.js
@@ -15,7 +15,7 @@ export default function traverse(source, filename, opts) {
       allowImportExportEverywhere: true,
       allowReturnOutsideFunction: true,
       allowSuperOutsideMethod: true,
-      sourceType: 'unambigious',
+      sourceType: 'unambiguous',
       sourceFilename: true,
 
       plugins: [


### PR DESCRIPTION
This fixes the following error:

```
Unknown sourceType "unambigious", cannot transform.
```