### PR TITLE
Update README: add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [Keyframes and global](#keyframes-and-global)
   - [With props](#with-props)
   - [`as` prop](#as-prop)
+- [Installation](#installation)
 - [Setup](#setup)
   - [Options](#options)
   - [Use without webpack](#use-without-webpack)
@@ -347,6 +348,12 @@ const Button = styled('button')`
 const StyledFooter = styled(Footer, { allowAs: true })`
   color: red;
 `
+```
+
+## Installation
+
+```shell
+npm install --save-dev astroturf
 ```
 
 ## Setup


### PR DESCRIPTION
I almost always check the docs for install instructions since not all libs go by the same name in the `npm` registry.