### PR TITLE
Fix "Cannot read property node" error

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,14 +1,15 @@
+import { basename, dirname, extname, join, relative } from 'path';
 import { stripIndent } from 'common-tags';
 import { outputFileSync } from 'fs-extra';
 import camelCase from 'lodash/camelCase';
 import get from 'lodash/get';
 import kebabCase from 'lodash/kebabCase';
-import { dirname, extname, basename, join, relative } from 'path';
-import * as t from '@babel/types';
-import template from '@babel/template';
 import generate from '@babel/generator';
-import pascalCase from './utils/pascalCase';
+import template from '@babel/template';
+import * as t from '@babel/types';
+
 import getNameFromPath from './utils/getNameFromPath';
+import pascalCase from './utils/pascalCase';
 import wrapInClass from './utils/wrapInClass';
 
 const buildImport = template('require(FILENAME);');
@@ -177,6 +178,8 @@ export default function plugin() {
         const decl = !path.isImportDeclaration()
           ? path.findParent(p => p.isImportDeclaration())
           : path;
+
+        if (!decl) return;
 
         const { start, end } = decl.node;
 


### PR DESCRIPTION
Fixes https://github.com/4Catalyzer/astroturf/issues/64 error.

The current behavior:

1. Collect all imports on `ImportDeclaration`.
2. Run all other babel plugins
3. On post-processing step do something with imports.

But what if the project has another Babel plugins? The error happens when another plugin removes or change one of the collected imports during step 1.

For instance, our Babel config:

```json
  "env": {
    "test": {
      "plugins": [
        "babel-plugin-dynamic-import-node",
        [
          "astroturf/plugin",
          {
            "allowGlobal": true,
            "writeFiles": false
          }
        ],
        [
          "babel-plugin-transform-rename-import",
          {
            "replacements": [
              {
                "original": "^.*\\.(css|less|sss)$",
                "replacement": "identity-obj-proxy"
              }
            ]
          }
        ]
      ]
    }
  }
```

In this config we use `babel-plugin-transform-rename-import` plugin to remove `.css` imports to run components in Jest.

`babel-plugin-transform-rename-import` changes imports and Astrorturf post-processing step fails.

Even if this way is not a correct, still we can’t 100% relay in imports collected in step 1. This PR make post-processing more error tolerant for cases when import was changed.