### PR TITLE
fix: allow multiline attrs()

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -31,7 +31,10 @@ function collectStyles(src, filename, opts) {
   // quick regex as an optimization to avoid parsing each file
   if (
     !src.match(
-      new RegExp(`(${tagName}|${styledTag}.+?)\\s*\`([\\s\\S]*?)\``, 'gmi'),
+     new RegExp(
+        `(${tagName}|${styledTag}(.|\\n|\\r)+?)\\s*\`([\\s\\S]*?)\``,
+        'gmi',
+      ),
     )
   ) {
     return { styles: [] };


### PR DESCRIPTION
```
styled('h2').attrs({

})``
```