### PR TITLE
better interpolation

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -18,9 +18,7 @@ const buildComponent = template(
   `styled(ELEMENTTYPE, OPTIONS, {
     displayName: DISPLAYNAME,
     styles: IMPORT,
-    attrs: ATTRS,
-    kebabName: KEBABNAME,
-    camelName: CAMELNAME
+    attrs: ATTRS
   })`,
 );
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,10 +1,8 @@
 import { basename, dirname, extname, join, relative } from 'path';
 import { stripIndent } from 'common-tags';
 import { outputFileSync } from 'fs-extra';
-import camelCase from 'lodash/camelCase';
 import defaults from 'lodash/defaults';
 import get from 'lodash/get';
-import kebabCase from 'lodash/kebabCase';
 import generate from '@babel/generator';
 import template from '@babel/template';
 import * as t from '@babel/types';
@@ -178,9 +176,7 @@ export default function plugin() {
       opts.pluginOptions,
     );
 
-    const kebabName = kebabCase(displayName);
-    style.name = kebabName;
-    style.value = imports + wrapInClass(`.${style.name}`, text);
+    style.value = imports + wrapInClass(text);
 
     const runtimeNode = buildComponent({
       ELEMENTTYPE: elementType,
@@ -190,8 +186,6 @@ export default function plugin() {
       IMPORT: buildImport({
         FILENAME: t.StringLiteral(style.relativeFilePath),
       }).expression,
-      KEBABNAME: t.StringLiteral(kebabName),
-      CAMELNAME: t.StringLiteral(camelCase(kebabName)),
     });
 
     if (pluginOptions.generateInterpolations)

--- a/src/runtime/styled.js
+++ b/src/runtime/styled.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 const React = require('react'); // eslint-disable-line import/no-extraneous-dependencies
 
 // eslint-disable-next-line no-control-regex
@@ -10,16 +11,16 @@ const camelCase = str =>
   );
 
 function styled(type, options, settings) {
-  const { displayName, attrs, styles, kebabName, camelName } = settings;
+  const { displayName, attrs, styles } = settings;
 
   options = options || { allowAs: typeof type === 'string' };
-  const componentClassName = styles[kebabName] || styles[camelName];
+  const componentClassName = styles.cls2 || styles.cls1;
 
   // always passthrough if the type is a styled component
   const allowAs = type.isAstroturf ? false : options.allowAs;
 
   const hasModifiers = Object.keys(styles).some(
-    className => className !== camelName && className !== kebabName,
+    className => className !== componentClassName,
   );
 
   function Styled(rawProps, ref) {

--- a/src/runtime/styled.js
+++ b/src/runtime/styled.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 const React = require('react'); // eslint-disable-line import/no-extraneous-dependencies
 
 // eslint-disable-next-line no-control-regex

--- a/src/utils/buildTaggedTemplate.js
+++ b/src/utils/buildTaggedTemplate.js
@@ -1,5 +1,4 @@
 import { dirname, relative } from 'path';
-import { stripIndent } from 'common-tags';
 import groupBy from 'lodash/groupBy';
 import uniq from 'lodash/uniq';
 
@@ -18,7 +17,7 @@ function resolveInterpolation(path, nodeMap, localStyle) {
     isStyledComponent: style.isStyledComponent,
     externalName: !style.isStyledComponent
       ? path.get('property').node.name
-      : style.name,
+      : 'cls1',
     importName: relative(
       dirname(localStyle.absoluteFilePath),
       style.absoluteFilePath,
@@ -106,11 +105,7 @@ export default (path, nodeMap, localStyle, { tagName }) => {
     const { externalName, importName } = interpolations.get(match);
     const localName = `a${id++}`;
 
-    imports += stripIndent`
-        :import("${importName}") {
-          ${localName}: ${externalName};
-        }\n
-      `;
+    imports += `@value ${externalName} as ${localName} from "${importName}";\n`;
     return `.${localName}`;
   });
 

--- a/src/utils/wrapInClass.js
+++ b/src/utils/wrapInClass.js
@@ -1,17 +1,35 @@
-export default function wrapInClass(className, value) {
+import { stripIndents } from 'common-tags';
+
+export default function wrapInClass(text) {
   const imports = [];
+  const composes = [];
 
   let match;
-  const matcher = /@import.*?(?:$|;)/g;
+  const rImports = /@import.*?(?:$|;)/g;
+  const rComposes = /\b(?:composes\s*?:\s*(.*?)(?:from\s(.+?))?(?=[}\n\r]))/gim;
 
   // eslint-disable-next-line no-cond-assign
-  while ((match = matcher.exec(value))) {
+  while ((match = rImports.exec(text))) {
     imports.push(match[0]);
   }
+  match = null;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = rComposes.exec(text))) {
+    composes.push(match[0]);
+  }
 
-  value = value.replace(matcher, '');
+  text = text.replace(rImports, '').replace(rComposes, '');
 
-  let val = `${className} {\n${value}\n}`;
+  let val = stripIndents`
+    .cls1 {
+      ${text.trim()}
+    }`;
+
+  if (composes.length) {
+    composes.unshift(`composes: cls1;`);
+    val += `\n.cls2 {\n${composes.join('\n')}\n}`;
+  }
+
   if (imports.length) val = `${imports.join('\n')}\n${val}`;
   return val;
 }

--- a/src/utils/wrapInClass.js
+++ b/src/utils/wrapInClass.js
@@ -20,11 +20,17 @@ export default function wrapInClass(text) {
 
   text = text.replace(rImports, '').replace(rComposes, '');
 
+  // comment prevents Sass from removing the empty class
   let val = stripIndents`
     .cls1 {
-      ${text.trim()}
+      ${text.trim() || '/*!*/'}
     }`;
 
+  // Components need two css classes, the first being the single root
+  // class with styles and the second is the exported name used in the Styled helper
+  // We need both so that that interpolations have a class that is _only_
+  // the single class, e.g. no additional classes composed in so that it can be used
+  // as a selecto
   if (composes.length) {
     composes.unshift(`composes: cls1;`);
     val += `\n.cls2 {\n${composes.join('\n')}\n}`;

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -2,33 +2,33 @@
 
 exports[`webpack integration should work 1`] = `
 "
-  .index-styles__parent--1oDPf {
+  .index-styles__parent {
     color: red;
   }
 
-.index-FancyBox__fancy-box--1DG83 {
-
-  color: red;
-  width: 75px;
-
+.index-FancyBox__cls1 {
+color: red;
+width: 75px;
 }
 
-  .index-FancyBox__fancy-box--1DG83.index-FancyBox__primary--3zeTZ {
-    background: white;
-    color: palevioletred;
-  }
-.index-FancierBox__fancier-box--3Wzgh {
-
-  color: ultra-red;
-
+.index-FancyBox__cls1.index-FancyBox__primary {
+background: white;
+color: palevioletred;
+}
+.index-FancyBox__cls2 {
+}
+.index-FancierBox__cls1 {
+color: ultra-red;
 }
 
-.index-FancierBox__fancier-box--3Wzgh > .index-FancyBox__fancy-box--1DG83 {
-    padding: 4em;
-  }
 
-.index-styles__parent--1oDPf > .index-FancierBox__fancier-box--3Wzgh {
-    margin: 2em;
-  }
+.index-FancierBox__cls1 > .index-FancyBox__cls1 {
+padding: 4em;
+}
+
+
+.index-styles__parent > .index-FancierBox__cls1 {
+margin: 2em;
+}
 "
 `;

--- a/test/__snapshots__/integration.test.js.snap
+++ b/test/__snapshots__/integration.test.js.snap
@@ -30,5 +30,10 @@ padding: 4em;
 .index-styles__parent > .index-FancierBox__cls1 {
 margin: 2em;
 }
+.index-Button__cls1 {
+/*!*/
+}
+.index-Button__cls2 {
+}
 "
 `;

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -12,18 +12,14 @@ exports[`Loader css-no-assignment js : Compilation Error 1`] = `
 `;
 
 exports[`Loader display-name 0: display-name-FooBarBaz.css 1`] = `
-".foo-bar-baz {
-
-  color: red;
-
+".cls1 {
+color: red;
 }"
 `;
 
 exports[`Loader display-name 1: DisplayName.css 1`] = `
-".display-name {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
@@ -51,21 +47,19 @@ export default styled(FancyBox, null, {
 `;
 
 exports[`Loader element-shorthand 0: element-shorthand-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-    width: 96px;
-    height: 96px;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -111,15 +105,11 @@ const styles = require('./example-styles.less');
 
 exports[`Loader hoist-import 0: hoist-import-ButtonBase.css 1`] = `
 "@import '~./styles/mixins.scss';
-.button-base {
-
-  
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-
+.cls1 {
+display: inline-flex;
+align-items: center;
+justify-content: center;
+border: 1px solid transparent;
 }"
 `;
 
@@ -168,23 +158,17 @@ const styles = require('./imports-mixed-styles.css');
 
 exports[`Loader index 0: index-ButtonBase.css 1`] = `
 "@import '~./styles/mixins.scss';
-.button-base {
-
-  
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-
+.cls1 {
+display: inline-flex;
+align-items: center;
+justify-content: center;
+border: 1px solid transparent;
 }"
 `;
 
 exports[`Loader index 1: Fixtures.css 1`] = `
-".fixtures {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
@@ -210,35 +194,31 @@ export default styled(FancyBox, null, {
 `;
 
 exports[`Loader multiple-components 0: multiple-components-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-		width: 96px;
-		height: 96px;
-	}
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
 exports[`Loader multiple-components 1: multiple-components-FancyHeader.css 1`] = `
-".fancy-header {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -286,29 +266,25 @@ const styles = less\`
 `;
 
 exports[`Loader pass-options 0: pass-options-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-    width: 96px;
-    height: 96px;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
 exports[`Loader pass-options 1: pass-options-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
@@ -341,29 +317,29 @@ const FancierBox = styled(FancyBox, options, {
 `;
 
 exports[`Loader styled 0: styled-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-    width: 96px;
-    height: 96px;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
 exports[`Loader styled 1: styled-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
+}
+.cls2 {
+composes: cls1;
+composes: bar foo from global;
 }"
 `;
 
@@ -392,23 +368,19 @@ const FancierBox = styled(FancyBox, null, {
 `;
 
 exports[`Loader styled-global 0: styled-global-FancyBox.css 1`] = `
-".fancy-box {
-
-  color: red;
-  width: 75px;
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+".cls1 {
+color: red;
+width: 75px;
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
 exports[`Loader styled-global 1: styled-global-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
@@ -441,9 +413,8 @@ exports[`Loader styled-interpolations 0: styled-interpolations-base.css 1`] = `
 `;
 
 exports[`Loader styled-interpolations 1: styled-interpolations-other.css 1`] = `
-":import(\\"styled-interpolations-base.css\\") {
-  a1: item;
-}
+"@value item as a1 from \\"styled-interpolations-base.css\\";
+
 
 
   .other .a1 {
@@ -453,43 +424,40 @@ exports[`Loader styled-interpolations 1: styled-interpolations-other.css 1`] = `
 `;
 
 exports[`Loader styled-interpolations 2: styled-interpolations-FancyBox.css 1`] = `
-":import(\\"styled-interpolations-base.css\\") {
-  a6: item;
+"@value item as a6 from \\"styled-interpolations-base.css\\";
+
+
+.cls1 {
+color: red;
+width: 75px;
+
+&.a6 {
+padding: 5rem;
 }
 
-.fancy-box {
-
-  composes: other from \\"styled-interpolations-other.css\\";
+&.primary {
+background: white;
+color: palevioletred;
+}
+}
+.cls2 {
+composes: cls1;
+composes: global from global;
+composes: other from \\"styled-interpolations-other.css\\";
 composes: item from \\"styled-interpolations-base.css\\";
-
-  color: red;
-  width: 75px;
-
-  &.a6 {
-    padding: 5rem;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
 }"
 `;
 
 exports[`Loader styled-interpolations 3: styled-interpolations-FancierBox.css 1`] = `
-":import(\\"styled-interpolations-FancyBox.css\\") {
-  a8: fancy-box;
+"@value cls1 as a8 from \\"styled-interpolations-FancyBox.css\\";
+
+
+.cls1 {
+color: ultra-red;
+
+> .a8 {
+padding: 4em;
 }
-
-.fancier-box {
-
-  color: ultra-red;
-
-  > .a8 {
-    padding: 4em;
-  }
-
 }"
 `;
 
@@ -528,23 +496,19 @@ exports[`Loader styled-no-assignment js : Compilation Error 1`] = `
 `;
 
 exports[`Loader styled-tag 0: styled-tag-FancyBox.css 1`] = `
-".fancy-box {
-
-  color: red;
-  width: 75px;
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+".cls1 {
+color: red;
+width: 75px;
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
 exports[`Loader styled-tag 1: styled-tag-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
@@ -615,18 +579,14 @@ class Component extends React.Component<PropsType, {}> {
 `;
 
 exports[`Loader with-props 0: with-props-RedPasswordInput.css 1`] = `
-".red-password-input {
-
-  background-color: red;
-
+".cls1 {
+background-color: red;
 }"
 `;
 
 exports[`Loader with-props 1: with-props-RedPasswordInput2.css 1`] = `
-".red-password-input-2 {
-
-  background-color: red;
-
+".cls1 {
+background-color: red;
 }"
 `;
 

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -31,17 +31,13 @@ const bar = 'Bar';
 Foo[bar]['baz'] = styled('div', null, {
   displayName: \\"FooBarBaz\\",
   styles: require(\\"./display-name-FooBarBaz.css\\"),
-  attrs: null,
-  kebabName: \\"foo-bar-baz\\",
-  camelName: \\"fooBarBaz\\"
+  attrs: null
 });
 
 export default styled(FancyBox, null, {
   displayName: \\"DisplayName\\",
   styles: require(\\"./DisplayName.css\\"),
-  attrs: null,
-  kebabName: \\"display-name\\",
-  camelName: \\"displayName\\"
+  attrs: null
 });
 "
 `;
@@ -71,9 +67,7 @@ const SIZE = 75;
 const FancyBox = styled(\\"div\\", null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./element-shorthand-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 "
 `;
@@ -119,9 +113,7 @@ exports[`Loader hoist-import js : Compiled JS 1`] = `
 const ButtonBase = styled('button', null, {
   displayName: \\"ButtonBase\\",
   styles: require(\\"./hoist-import-ButtonBase.css\\"),
-  attrs: null,
-  kebabName: \\"button-base\\",
-  camelName: \\"buttonBase\\"
+  attrs: null
 });
 "
 `;
@@ -178,17 +170,13 @@ exports[`Loader index js : Compiled JS 1`] = `
 const ButtonBase = styled('button', null, {
   displayName: \\"ButtonBase\\",
   styles: require(\\"./index-ButtonBase.css\\"),
-  attrs: null,
-  kebabName: \\"button-base\\",
-  camelName: \\"buttonBase\\"
+  attrs: null
 });
 
 export default styled(FancyBox, null, {
   displayName: \\"Fixtures\\",
   styles: require(\\"./Fixtures.css\\"),
-  attrs: null,
-  kebabName: \\"fixtures\\",
-  camelName: \\"fixtures\\"
+  attrs: null
 });
 "
 `;
@@ -231,17 +219,13 @@ const SIZE = 75;
 const FancyBox = styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./multiple-components-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 
 const FancyHeader = styled('h2', null, {
   displayName: \\"FancyHeader\\",
   styles: require(\\"./multiple-components-FancyHeader.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-header\\",
-  camelName: \\"fancyHeader\\"
+  attrs: null
 });
 "
 `;
@@ -299,9 +283,7 @@ const FancyBox = styled('div', {
 }, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./pass-options-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 
 const options = {};
@@ -309,9 +291,7 @@ const options = {};
 const FancierBox = styled(FancyBox, options, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./pass-options-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });
 "
 `;
@@ -352,17 +332,13 @@ const SIZE = 75;
 const FancyBox = styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 
 const FancierBox = styled(FancyBox, null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });
 "
 `;
@@ -389,17 +365,13 @@ exports[`Loader styled-global js : Compiled JS 1`] = `
 const FancyBox = styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-global-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 
 const FancierBox = styled(FancyBox, null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-global-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });
 "
 `;
@@ -461,6 +433,16 @@ padding: 4em;
 }"
 `;
 
+exports[`Loader styled-interpolations 4: styled-interpolations-Button.css 1`] = `
+".cls1 {
+/*!*/
+}
+.cls2 {
+composes: cls1;
+composes: button-with-caret from global;
+}"
+`;
+
 exports[`Loader styled-interpolations js : Compiled JS 1`] = `
 "import styled from 'astroturf'
 
@@ -471,17 +453,19 @@ const other = require('./styled-interpolations-other.css');
 const FancyBox = styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-interpolations-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 
 const FancierBox = styled('div', null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-interpolations-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
+});
+
+const Button = styled(Button, null, {
+  displayName: \\"Button\\",
+  styles: require(\\"./styled-interpolations-Button.css\\"),
+  attrs: null
 });
 "
 `;
@@ -519,17 +503,13 @@ exports[`Loader styled-tag js : Compiled JS 1`] = `
 const FancyBox = styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-tag-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 
 const FancierBox = styled(FancyBox, null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-tag-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });
 "
 `;
@@ -598,9 +578,7 @@ const RedPasswordInput = styled('input', null, {
   styles: require(\\"./with-props-RedPasswordInput.css\\"),
   attrs: props => ({ ...props,
     type: 'password'
-  }),
-  kebabName: \\"red-password-input\\",
-  camelName: \\"redPasswordInput\\"
+  })
 });
 
 const RedPasswordInput2 = styled('input', null, {
@@ -608,9 +586,7 @@ const RedPasswordInput2 = styled('input', null, {
   styles: require(\\"./with-props-RedPasswordInput2.css\\"),
   attrs: p => ({
     type: 'password'
-  }),
-  kebabName: \\"red-password-input-2\\",
-  camelName: \\"redPasswordInput2\\"
+  })
 });
 "
 `;

--- a/test/__snapshots__/plugin.test.js.snap
+++ b/test/__snapshots__/plugin.test.js.snap
@@ -12,18 +12,14 @@ exports[`Plugin css-no-assignment js : Compilation Error 1`] = `
 `;
 
 exports[`Plugin display-name DisplayName: DisplayName.css 1`] = `
-".display-name {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
 exports[`Plugin display-name FooBarBaz: display-name-FooBarBaz.css 1`] = `
-".foo-bar-baz {
-
-  color: red;
-
+".cls1 {
+color: red;
 }"
 `;
 
@@ -54,21 +50,19 @@ styled(FancyBox, null, {
 `;
 
 exports[`Plugin element-shorthand FancyBox: element-shorthand-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-    width: 96px;
-    height: 96px;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -112,15 +106,11 @@ exports[`Plugin example styles: example-styles.less 1`] = `
 
 exports[`Plugin hoist-import ButtonBase: hoist-import-ButtonBase.css 1`] = `
 "@import '~./styles/mixins.scss';
-.button-base {
-
-  
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-
+.cls1 {
+display: inline-flex;
+align-items: center;
+justify-content: center;
+border: 1px solid transparent;
 }"
 `;
 
@@ -169,23 +159,17 @@ exports[`Plugin imports-mixed styles: imports-mixed-styles.css 1`] = `
 
 exports[`Plugin index ButtonBase: index-ButtonBase.css 1`] = `
 "@import '~./styles/mixins.scss';
-.button-base {
-
-  
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid transparent;
-
+.cls1 {
+display: inline-flex;
+align-items: center;
+justify-content: center;
+border: 1px solid transparent;
 }"
 `;
 
 exports[`Plugin index Fixtures: Fixtures.css 1`] = `
-".fixtures {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
@@ -212,35 +196,31 @@ styled(FancyBox, null, {
 `;
 
 exports[`Plugin multiple-components FancyBox: multiple-components-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-		width: 96px;
-		height: 96px;
-	}
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
 exports[`Plugin multiple-components FancyHeader: multiple-components-FancyHeader.css 1`] = `
-".fancy-header {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -286,29 +266,25 @@ const styles = less\`
 `;
 
 exports[`Plugin pass-options FancierBox: pass-options-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
 exports[`Plugin pass-options FancyBox: pass-options-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-    width: 96px;
-    height: 96px;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -340,29 +316,29 @@ styled(FancyBox, options, {
 `;
 
 exports[`Plugin styled FancierBox: styled-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
+}
+.cls2 {
+composes: cls1;
+composes: bar foo from global;
 }"
 `;
 
 exports[`Plugin styled FancyBox: styled-FancyBox.css 1`] = `
-".fancy-box {
+".cls1 {
+color: red;
+width: 75px;
 
-  color: red;
-  width: 75px;
+@media (min-width: 420px) {
+width: 96px;
+height: 96px;
+}
 
-  @media (min-width: 420px) {
-    width: 96px;
-    height: 96px;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -391,23 +367,19 @@ styled(FancyBox, null, {
 `;
 
 exports[`Plugin styled-global FancierBox: styled-global-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
 exports[`Plugin styled-global FancyBox: styled-global-FancyBox.css 1`] = `
-".fancy-box {
-
-  color: red;
-  width: 75px;
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+".cls1 {
+color: red;
+width: 75px;
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -434,43 +406,40 @@ styled(FancyBox, null, {
 `;
 
 exports[`Plugin styled-interpolations FancierBox: styled-interpolations-FancierBox.css 1`] = `
-":import(\\"styled-interpolations-FancyBox.css\\") {
-  a8: fancy-box;
+"@value cls1 as a8 from \\"styled-interpolations-FancyBox.css\\";
+
+
+.cls1 {
+color: ultra-red;
+
+> .a8 {
+padding: 4em;
 }
-
-.fancier-box {
-
-  color: ultra-red;
-
-  > .a8 {
-    padding: 4em;
-  }
-
 }"
 `;
 
 exports[`Plugin styled-interpolations FancyBox: styled-interpolations-FancyBox.css 1`] = `
-":import(\\"styled-interpolations-base.css\\") {
-  a6: item;
+"@value item as a6 from \\"styled-interpolations-base.css\\";
+
+
+.cls1 {
+color: red;
+width: 75px;
+
+&.a6 {
+padding: 5rem;
 }
 
-.fancy-box {
-
-  composes: other from \\"styled-interpolations-other.css\\";
+&.primary {
+background: white;
+color: palevioletred;
+}
+}
+.cls2 {
+composes: cls1;
+composes: global from global;
+composes: other from \\"styled-interpolations-other.css\\";
 composes: item from \\"styled-interpolations-base.css\\";
-
-  color: red;
-  width: 75px;
-
-  &.a6 {
-    padding: 5rem;
-  }
-
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
 }"
 `;
 
@@ -514,9 +483,8 @@ styled('div', null, {
 `;
 
 exports[`Plugin styled-interpolations other: styled-interpolations-other.css 1`] = `
-":import(\\"styled-interpolations-base.css\\") {
-  a1: item;
-}
+"@value item as a1 from \\"styled-interpolations-base.css\\";
+
 
 
   .other .a1 {
@@ -535,23 +503,19 @@ exports[`Plugin styled-no-assignment js : Compilation Error 1`] = `
 `;
 
 exports[`Plugin styled-tag FancierBox: styled-tag-FancierBox.css 1`] = `
-".fancier-box {
-
-  color: ultra-red;
-
+".cls1 {
+color: ultra-red;
 }"
 `;
 
 exports[`Plugin styled-tag FancyBox: styled-tag-FancyBox.css 1`] = `
-".fancy-box {
-
-  color: red;
-  width: 75px;
-  &.primary {
-    background: white;
-    color: palevioletred;
-  }
-
+".cls1 {
+color: red;
+width: 75px;
+&.primary {
+background: white;
+color: palevioletred;
+}
 }"
 `;
 
@@ -579,18 +543,14 @@ styled(FancyBox, null, {
 `;
 
 exports[`Plugin with-props RedPasswordInput: with-props-RedPasswordInput.css 1`] = `
-".red-password-input {
-
-  background-color: red;
-
+".cls1 {
+background-color: red;
 }"
 `;
 
 exports[`Plugin with-props RedPasswordInput2: with-props-RedPasswordInput2.css 1`] = `
-".red-password-input-2 {
-
-  background-color: red;
-
+".cls1 {
+background-color: red;
 }"
 `;
 

--- a/test/__snapshots__/plugin.test.js.snap
+++ b/test/__snapshots__/plugin.test.js.snap
@@ -34,18 +34,14 @@ Foo[bar]['baz'] =
 styled('div', null, {
   displayName: \\"FooBarBaz\\",
   styles: require(\\"./display-name-FooBarBaz.css\\"),
-  attrs: null,
-  kebabName: \\"foo-bar-baz\\",
-  camelName: \\"fooBarBaz\\"
+  attrs: null
 });
 export default
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: \\"DisplayName\\",
   styles: require(\\"./DisplayName.css\\"),
-  attrs: null,
-  kebabName: \\"display-name\\",
-  camelName: \\"displayName\\"
+  attrs: null
 });"
 `;
 
@@ -74,9 +70,7 @@ const FancyBox =
 styled(\\"div\\", null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./element-shorthand-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });"
 `;
 
@@ -121,9 +115,7 @@ const ButtonBase =
 styled('button', null, {
   displayName: \\"ButtonBase\\",
   styles: require(\\"./hoist-import-ButtonBase.css\\"),
-  attrs: null,
-  kebabName: \\"button-base\\",
-  camelName: \\"buttonBase\\"
+  attrs: null
 });"
 `;
 
@@ -180,18 +172,14 @@ const ButtonBase =
 styled('button', null, {
   displayName: \\"ButtonBase\\",
   styles: require(\\"./index-ButtonBase.css\\"),
-  attrs: null,
-  kebabName: \\"button-base\\",
-  camelName: \\"buttonBase\\"
+  attrs: null
 });
 export default
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: \\"Fixtures\\",
   styles: require(\\"./Fixtures.css\\"),
-  attrs: null,
-  kebabName: \\"fixtures\\",
-  camelName: \\"fixtures\\"
+  attrs: null
 });"
 `;
 
@@ -233,18 +221,14 @@ const FancyBox =
 styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./multiple-components-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 const FancyHeader =
 /*#__PURE__*/
 styled('h2', null, {
   displayName: \\"FancyHeader\\",
   styles: require(\\"./multiple-components-FancyHeader.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-header\\",
-  camelName: \\"fancyHeader\\"
+  attrs: null
 });"
 `;
 
@@ -299,9 +283,7 @@ styled('div', {
 }, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./pass-options-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 const options = {};
 const FancierBox =
@@ -309,9 +291,7 @@ const FancierBox =
 styled(FancyBox, options, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./pass-options-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });"
 `;
 
@@ -351,18 +331,14 @@ const FancyBox =
 styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 const FancierBox =
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });"
 `;
 
@@ -390,19 +366,25 @@ const FancyBox =
 styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-global-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 const FancierBox =
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-global-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });"
+`;
+
+exports[`Plugin styled-interpolations Button: styled-interpolations-Button.css 1`] = `
+".cls1 {
+/*!*/
+}
+.cls2 {
+composes: cls1;
+composes: button-with-caret from global;
+}"
 `;
 
 exports[`Plugin styled-interpolations FancierBox: styled-interpolations-FancierBox.css 1`] = `
@@ -467,18 +449,21 @@ const FancyBox =
 styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-interpolations-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 const FancierBox =
 /*#__PURE__*/
 styled('div', null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-interpolations-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
+});
+const Button =
+/*#__PURE__*/
+styled(Button, null, {
+  displayName: \\"Button\\",
+  styles: require(\\"./styled-interpolations-Button.css\\"),
+  attrs: null
 });"
 `;
 
@@ -527,18 +512,14 @@ const FancyBox =
 styled('div', null, {
   displayName: \\"FancyBox\\",
   styles: require(\\"./styled-tag-FancyBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancy-box\\",
-  camelName: \\"fancyBox\\"
+  attrs: null
 });
 const FancierBox =
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: \\"FancierBox\\",
   styles: require(\\"./styled-tag-FancierBox.css\\"),
-  attrs: null,
-  kebabName: \\"fancier-box\\",
-  camelName: \\"fancierBox\\"
+  attrs: null
 });"
 `;
 
@@ -563,9 +544,7 @@ styled('input', null, {
   styles: require(\\"./with-props-RedPasswordInput.css\\"),
   attrs: props => ({ ...props,
     type: 'password'
-  }),
-  kebabName: \\"red-password-input\\",
-  camelName: \\"redPasswordInput\\"
+  })
 });
 const RedPasswordInput2 =
 /*#__PURE__*/
@@ -574,8 +553,6 @@ styled('input', null, {
   styles: require(\\"./with-props-RedPasswordInput2.css\\"),
   attrs: p => ({
     type: 'password'
-  }),
-  kebabName: \\"red-password-input-2\\",
-  camelName: \\"redPasswordInput2\\"
+  })
 });"
 `;

--- a/test/fixtures/styled-interpolations.js
+++ b/test/fixtures/styled-interpolations.js
@@ -13,6 +13,7 @@ const other = css`
 `;
 
 const FancyBox = styled('div')`
+  composes: global from global;
   composes: ${other.other} ${other.other} ${base.item};
 
   color: red;

--- a/test/fixtures/styled-interpolations.js
+++ b/test/fixtures/styled-interpolations.js
@@ -36,3 +36,7 @@ const FancierBox = styled('div')`
     padding: 4em;
   }
 `;
+
+const Button = styled(Button)`
+  composes: button-with-caret from global;
+`;

--- a/test/fixtures/styled.js
+++ b/test/fixtures/styled.js
@@ -19,5 +19,7 @@ const FancyBox = styled('div')`
 `;
 
 const FancierBox = styled(FancyBox)`
+  composes: bar foo from global;
+
   color: ultra-red;
 `;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -28,7 +28,7 @@ describe('webpack integration', () => {
                 loader: require.resolve('../src/css-loader'),
                 options: {
                   modules: {
-                    localIdentName: '[name]__[local]--[hash:base64:5]',
+                    localIdentName: '[name]__[local]',
                   },
                 },
               },

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -10,6 +10,8 @@ const styles = css`
 `;
 
 const FancyBox = styled('div')`
+  composes: foo from global;
+
   color: red;
   width: ${width}px;
 

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -33,4 +33,8 @@ const FancierBox = styled('div')`
   }
 `;
 
+export const Button = styled('button')`
+  composes: button-with-caret from global;
+`;
+
 export default FancierBox;


### PR DESCRIPTION
OK few things here. 

- `libsass` can't parse `:import("whatever")` it complains about the string.
- using the exported identifier for just the class gives the wrong output for classes that have `composes`, the value there will be all the classes not just the one we want, so we need a seperate className that can be used for interpolating

The alternative to this would be to create an empty hook class and compose that into the class with the selector but that feels a bit off since interpolated selectors would target the empty class, and you can't do any optimizations like remove the empty classes, whereas here you could since the output classnames are unimportant, they are only used from the js side.