### PR TITLE
feat: add support for custom css properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,11 @@
       "git add"
     ]
   },
+  "importSort": {
+    ".js, .ts, .tsx": {
+      "style": "@4c/import-sort"
+    }
+  },
   "prettier": {
     "printWidth": 79,
     "singleQuote": true,

--- a/src/runtime/styled.js
+++ b/src/runtime/styled.js
@@ -9,6 +9,16 @@ const camelCase = str =>
     '',
   );
 
+function varsToStyles(props, vars) {
+  if (!vars || !vars.length) return props.style;
+  const style = { ...props.style };
+  vars.forEach(([id, value, unit = '']) => {
+    const result = typeof value === 'function' ? value(props) : value;
+    style[`--${id}`] = `${result}${unit}`;
+  });
+  return style;
+}
+
 function propsToStyles(props, styles, hasModifiers) {
   const componentClassName = styles.cls2 || styles.cls1;
   let className = props.className
@@ -71,7 +81,7 @@ function styled(type, options, settings) {
           'ensure that your versions are properly deduped and upgraded. ',
       );
   }
-  const { displayName, attrs, styles } = settings;
+  const { displayName, attrs, vars, styles } = settings;
 
   options = options || { allowAs: typeof type === 'string' };
 
@@ -87,7 +97,7 @@ function styled(type, options, settings) {
     const childProps = { ...props, ref };
 
     if (allowAs) delete childProps.as;
-
+    childProps.style = varsToStyles(childProps, vars);
     childProps.className = propsToStyles(childProps, styles, hasModifiers);
 
     return React.createElement(
@@ -112,7 +122,8 @@ function styled(type, options, settings) {
 function jsx(type, props, ...children) {
   if (props && props.css) {
     const { css, ...childProps } = props;
-    childProps.className = propsToStyles(childProps, css, true);
+    childProps.style = varsToStyles(childProps, css[1]);
+    childProps.className = propsToStyles(childProps, css[0] || css, true);
     props = childProps;
   }
   return React.createElement(type, props, ...children);

--- a/src/utils/cssUnits.js
+++ b/src/utils/cssUnits.js
@@ -1,0 +1,55 @@
+// https://www.w3.org/TR/css-values-4/
+export default [
+  // font relative lengths
+  'em',
+  'ex',
+  'cap',
+  'ch',
+  'ic',
+  'rem',
+  'lh',
+  'rlh',
+
+  // viewport percentage lengths
+  'vw',
+  'vh',
+  'vi',
+  'vb',
+  'vmin',
+  'vmax',
+
+  // absolute lengths
+  'cm',
+  'mm',
+  'Q',
+  'in',
+  'pc',
+  'pt',
+  'px',
+
+  // angle units
+  'deg',
+  'grad',
+  'rad',
+  'turn',
+
+  // duration units
+  's',
+  'ms',
+
+  // frequency units
+  'Hz',
+  'kHz',
+
+  // resolution units
+  'dpi',
+  'dpcm',
+  'dppx',
+  'x',
+
+  // https://www.w3.org/TR/css-grid-1/#fr-unit
+  'fr',
+
+  // percentages
+  '%',
+];

--- a/src/utils/murmurHash.js
+++ b/src/utils/murmurHash.js
@@ -1,0 +1,75 @@
+/* eslint-disable prefer-destructuring, no-bitwise, default-case */
+
+/**
+ * murmurhash2 via https://gist.github.com/raycmorgan/588423
+ */
+
+function UInt32(str, pos) {
+  return (
+    str.charCodeAt(pos++) +
+    (str.charCodeAt(pos++) << 8) +
+    (str.charCodeAt(pos++) << 16) +
+    (str.charCodeAt(pos) << 24)
+  );
+}
+
+function UInt16(str, pos) {
+  return str.charCodeAt(pos++) + (str.charCodeAt(pos++) << 8);
+}
+
+function Umul32(n, m) {
+  n |= 0;
+  m |= 0;
+  const nlo = n & 0xffff;
+  const nhi = n >>> 16;
+  const res = (nlo * m + (((nhi * m) & 0xffff) << 16)) | 0;
+  return res;
+}
+
+function doHash(str, seed = 0) {
+  const m = 0x5bd1e995;
+  const r = 24;
+  let h = seed ^ str.length;
+  let length = str.length;
+  let currentIndex = 0;
+
+  while (length >= 4) {
+    let k = UInt32(str, currentIndex);
+
+    k = Umul32(k, m);
+    k ^= k >>> r;
+    k = Umul32(k, m);
+
+    h = Umul32(h, m);
+    h ^= k;
+
+    currentIndex += 4;
+    length -= 4;
+  }
+
+  switch (length) {
+    case 3:
+      h ^= UInt16(str, currentIndex);
+      h ^= str.charCodeAt(currentIndex + 2) << 16;
+      h = Umul32(h, m);
+      break;
+
+    case 2:
+      h ^= UInt16(str, currentIndex);
+      h = Umul32(h, m);
+      break;
+
+    case 1:
+      h ^= str.charCodeAt(currentIndex);
+      h = Umul32(h, m);
+      break;
+  }
+
+  h ^= h >>> 13;
+  h = Umul32(h, m);
+  h ^= h >>> 15;
+
+  return h >>> 0;
+}
+
+export default code => doHash(code).toString(36);

--- a/test/__file_snapshots__/integration-js.js
+++ b/test/__file_snapshots__/integration-js.js
@@ -18,6 +18,16 @@ const camelCase = str =>
     '',
   );
 
+function varsToStyles(props, vars) {
+  if (!vars || !vars.length) return props.style;
+  const style = { ...props.style };
+  vars.forEach(([id, value, unit = '']) => {
+    const result = typeof value === 'function' ? value(props) : value;
+    style[`--${id}`] = `${result}${unit}`;
+  });
+  return style;
+}
+
 function propsToStyles(props, styles, hasModifiers) {
   const componentClassName = styles.cls2 || styles.cls1;
   let className = props.className
@@ -80,7 +90,7 @@ function styled(type, options, settings) {
           'ensure that your versions are properly deduped and upgraded. ',
       );
   }
-  const { displayName, attrs, styles } = settings;
+  const { displayName, attrs, vars, styles } = settings;
 
   options = options || { allowAs: typeof type === 'string' };
 
@@ -96,7 +106,7 @@ function styled(type, options, settings) {
     const childProps = { ...props, ref };
 
     if (allowAs) delete childProps.as;
-
+    childProps.style = varsToStyles(childProps, vars);
     childProps.className = propsToStyles(childProps, styles, hasModifiers);
 
     return React.createElement(
@@ -121,7 +131,8 @@ function styled(type, options, settings) {
 function jsx(type, props, ...children) {
   if (props && props.css) {
     const { css, ...childProps } = props;
-    childProps.className = propsToStyles(childProps, css, true);
+    childProps.style = varsToStyles(childProps, css[1]);
+    childProps.className = propsToStyles(childProps, css[0] || css, true);
     props = childProps;
   }
   return React.createElement(type, props, ...children);
@@ -185,7 +196,8 @@ const styles = __webpack_require__(/*! ./Button-styles.css */ "./test/integratio
 const Button = astroturf__WEBPACK_IMPORTED_MODULE_0___default()('button', null, {
   displayName: "Button",
   styles: __webpack_require__(/*! ./Button.css */ "./test/integration/Button.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 /* harmony default export */ __webpack_exports__["default"] = (Button);
 
@@ -291,12 +303,14 @@ const styles = __webpack_require__(/*! ./main-styles.css */ "./test/integration/
 const FancyBox = astroturf__WEBPACK_IMPORTED_MODULE_0___default()('div', null, {
   displayName: "FancyBox",
   styles: __webpack_require__(/*! ./main-FancyBox.css */ "./test/integration/main-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const FancierBox = astroturf__WEBPACK_IMPORTED_MODULE_0___default()('div', null, {
   displayName: "FancierBox",
   styles: __webpack_require__(/*! ./main-FancierBox.css */ "./test/integration/main-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 function MyComponent() {
   return _j(_f, null, _j("div", {
@@ -337,7 +351,8 @@ __webpack_require__.r(__webpack_exports__);
 const Widget = astroturf__WEBPACK_IMPORTED_MODULE_0___default()('div', null, {
   displayName: "Widget",
   styles: __webpack_require__(/*! ./Widget.css */ "./test/integration/shared/widget/Widget.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 /* harmony default export */ __webpack_exports__["default"] = (Widget);
 

--- a/test/__file_snapshots__/loader__element-shorthand.js
+++ b/test/__file_snapshots__/loader__element-shorthand.js
@@ -5,5 +5,6 @@ const SIZE = 75;
 const FancyBox = styled("div", null, {
   displayName: "FancyBox",
   styles: require("./element-shorthand-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__multiple-components.js
+++ b/test/__file_snapshots__/loader__multiple-components.js
@@ -6,11 +6,13 @@ const SIZE = 75;
 const FancyBox = styled('div', null, {
   displayName: "FancyBox",
   styles: require("./multiple-components-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const FancyHeader = styled('h2', null, {
   displayName: "FancyHeader",
   styles: require("./multiple-components-FancyHeader.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__pass-options.js
+++ b/test/__file_snapshots__/loader__pass-options.js
@@ -8,7 +8,8 @@ const FancyBox = styled('div', {
 }, {
   displayName: "FancyBox",
   styles: require("./pass-options-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const options = {};
@@ -16,5 +17,6 @@ const options = {};
 const FancierBox = styled(FancyBox, options, {
   displayName: "FancierBox",
   styles: require("./pass-options-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__styled-global.js
+++ b/test/__file_snapshots__/loader__styled-global.js
@@ -2,11 +2,13 @@
 const FancyBox = styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-global-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const FancierBox = styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-global-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__styled-interpolations.js
+++ b/test/__file_snapshots__/loader__styled-interpolations.js
@@ -7,17 +7,20 @@ const other = require('./styled-interpolations-other.css');
 const FancyBox = styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-interpolations-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const FancierBox = styled('div', null, {
   displayName: "FancierBox",
   styles: require("./styled-interpolations-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const Button = styled(Button, null, {
   displayName: "Button",
   styles: require("./styled-interpolations-Button.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__styled-tag.js
+++ b/test/__file_snapshots__/loader__styled-tag.js
@@ -4,11 +4,13 @@ import s from 'astroturf';
 const FancyBox = styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-tag-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const FancierBox = styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-tag-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__styled.js
+++ b/test/__file_snapshots__/loader__styled.js
@@ -6,11 +6,13 @@ const SIZE = 75;
 const FancyBox = styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 const FancierBox = styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/loader__typescript.tsx
+++ b/test/__file_snapshots__/loader__typescript.tsx
@@ -24,7 +24,8 @@ function someMath<T extends { x: number }>(obj: T): T {
 const Button = styled('button', null, {
   displayName: "Button",
   styles: require("./typescript-Button.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 
 class Component extends React.Component<PropsType> {

--- a/test/__file_snapshots__/loader__with-props.js
+++ b/test/__file_snapshots__/loader__with-props.js
@@ -5,7 +5,8 @@ const RedPasswordInput = styled('input', null, {
   styles: require("./with-props-RedPasswordInput.css"),
   attrs: props => ({ ...props,
     type: 'password'
-  })
+  }),
+  vars: []
 });
 
 const RedPasswordInput2 = styled('input', null, {
@@ -13,5 +14,6 @@ const RedPasswordInput2 = styled('input', null, {
   styles: require("./with-props-RedPasswordInput2.css"),
   attrs: p => ({
     type: 'password'
-  })
+  }),
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__css-prop.js
+++ b/test/__file_snapshots__/plugin__css-prop.js
@@ -8,17 +8,17 @@ import _default2 from "./css-prop-CssProp2_button.css";
 import _default from "./css-prop-CssProp1_button.css";
 
 function Button() {
-  return <button css={_default} />;
+  return <button css={[_default, []]} />;
 }
 
 function Button2() {
-  return <button css={_default2} />;
+  return <button css={[_default2]} />;
 }
 
 const color = 'orange';
 
 function Button3() {
   return <>
-      <button css={_default3} />
+      <button css={[_default3, []]} />
     </>;
 }

--- a/test/__file_snapshots__/plugin__element-shorthand.js
+++ b/test/__file_snapshots__/plugin__element-shorthand.js
@@ -5,5 +5,6 @@ const FancyBox =
 styled("div", null, {
   displayName: "FancyBox",
   styles: require("./element-shorthand-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__multiple-components.js
+++ b/test/__file_snapshots__/plugin__multiple-components.js
@@ -6,12 +6,14 @@ const FancyBox =
 styled('div', null, {
   displayName: "FancyBox",
   styles: require("./multiple-components-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const FancyHeader =
 /*#__PURE__*/
 styled('h2', null, {
   displayName: "FancyHeader",
   styles: require("./multiple-components-FancyHeader.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__pass-options.js
+++ b/test/__file_snapshots__/plugin__pass-options.js
@@ -8,7 +8,8 @@ styled('div', {
 }, {
   displayName: "FancyBox",
   styles: require("./pass-options-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const options = {};
 const FancierBox =
@@ -16,5 +17,6 @@ const FancierBox =
 styled(FancyBox, options, {
   displayName: "FancierBox",
   styles: require("./pass-options-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__styled-global.js
+++ b/test/__file_snapshots__/plugin__styled-global.js
@@ -4,12 +4,14 @@ const FancyBox =
 styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-global-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const FancierBox =
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-global-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__styled-interpolations.js
+++ b/test/__file_snapshots__/plugin__styled-interpolations.js
@@ -13,19 +13,22 @@ const FancyBox =
 styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-interpolations-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const FancierBox =
 /*#__PURE__*/
 styled('div', null, {
   displayName: "FancierBox",
   styles: require("./styled-interpolations-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const Button =
 /*#__PURE__*/
 styled(Button, null, {
   displayName: "Button",
   styles: require("./styled-interpolations-Button.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__styled-tag.js
+++ b/test/__file_snapshots__/plugin__styled-tag.js
@@ -5,12 +5,14 @@ const FancyBox =
 styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-tag-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const FancierBox =
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-tag-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__styled.js
+++ b/test/__file_snapshots__/plugin__styled.js
@@ -6,12 +6,14 @@ const FancyBox =
 styled('div', null, {
   displayName: "FancyBox",
   styles: require("./styled-FancyBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });
 const FancierBox =
 /*#__PURE__*/
 styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-FancierBox.css"),
-  attrs: null
+  attrs: null,
+  vars: []
 });

--- a/test/__file_snapshots__/plugin__with-props.js
+++ b/test/__file_snapshots__/plugin__with-props.js
@@ -6,7 +6,8 @@ styled('input', null, {
   styles: require("./with-props-RedPasswordInput.css"),
   attrs: props => ({ ...props,
     type: 'password'
-  })
+  }),
+  vars: []
 });
 const RedPasswordInput2 =
 /*#__PURE__*/
@@ -15,5 +16,6 @@ styled('input', null, {
   styles: require("./with-props-RedPasswordInput2.css"),
   attrs: p => ({
     type: 'password'
-  })
+  }),
+  vars: []
 });

--- a/test/css-prop.test.js
+++ b/test/css-prop.test.js
@@ -1,4 +1,5 @@
 import { mount } from 'enzyme';
+
 import { jsx } from '../src/index';
 import { run, runLoader } from './helpers';
 

--- a/test/custom-properties.test.js
+++ b/test/custom-properties.test.js
@@ -1,0 +1,105 @@
+import { mount } from 'enzyme';
+
+import { jsx } from '../src/index';
+import { run } from './helpers';
+
+describe('custom properties', () => {
+  it('should allow Styled dynamic interpolations', async () => {
+    const [code, [style]] = await run(
+      `
+        import styled from 'astroturf';
+
+        const Button = styled.button\`
+          color: \${p => p.color};
+        \`
+      `,
+      { customCssProperties: true },
+    );
+
+    const i = style.interpolations[0];
+
+    expect(code).toContain(`vars: [["${i.id}", p => p.color]]`);
+  });
+
+  it('should allow css prop dynamic interpolations ', async () => {
+    const [code, [style]] = await run(
+      `
+      import { css } from 'astroturf';
+
+      function Button({ color }) {
+        return (
+          <button
+            css={\`
+              color: \${color};
+            \`}
+          />
+        );
+      }
+      `,
+      { enableCssProp: true, customCssProperties: 'cssProp' },
+    );
+
+    const i = style.interpolations[0];
+
+    expect(code).toContain(`css={[_default, [["${i.id}", color]]]}`);
+  });
+
+  it.only('should disallow when configured off', async () => {
+    await expect(
+      run(
+        `
+      import styled, { css } from 'astroturf';
+
+      const ButtonA = styled.button\`
+        color: \${p => p.color};
+      \`
+
+      function ButtonB({ color }) {
+        return (
+          <button
+            css={\`
+              color: \${color};
+            \`}
+          />
+        );
+      }
+      `,
+        { enableCssProp: true, customCssProperties: false },
+      ),
+    ).rejects.toThrow(/Could not resolve interpolation to a value/);
+  });
+
+  it('should disallow Styled usage when configured off', async () => {
+    await expect(
+      run(
+        `
+      import styled, { css } from 'astroturf';
+
+      const ButtonA = styled.button\`
+        color: \${p => p.color};
+      \`
+      `,
+        { enableCssProp: true, customCssProperties: 'cssProp' },
+      ),
+    ).rejects.toThrow(/Could not resolve interpolation to a value/);
+  });
+
+  it('should apply styles', () => {
+    const wrapper = mount(
+      jsx('div', {
+        green: true,
+        css: [
+          {
+            cls1: 'cls1',
+            green: 'green',
+          },
+          [['aszd', 'blue']],
+        ],
+      }),
+    );
+    expect(wrapper.find('div.green')).toHaveLength(1);
+    expect(wrapper.prop('style')).toEqual({
+      '--aszd': 'blue',
+    });
+  });
+});

--- a/test/styled.test.js
+++ b/test/styled.test.js
@@ -1,10 +1,9 @@
-import { mount } from 'enzyme';
 import { stripIndent } from 'common-tags';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import { withProps } from '../src/helpers';
 import styled from '../src/index';
-
 import { run } from './helpers';
 
 describe('styled', () => {
@@ -32,7 +31,8 @@ describe('styled', () => {
         styled('button', null, {
           displayName: \"ButtonBase\",
           styles: require(\"./MyStyleFile-ButtonBase.css\"),
-          attrs: null
+          attrs: null,
+          vars: []
         });
       `,
     );

--- a/types/test.tsx
+++ b/types/test.tsx
@@ -1,9 +1,8 @@
 // TypeScript Version: 3.0
 
-import * as React from 'react';
 import styled, { css } from 'astroturf';
-
 import { mapProps, withProps } from 'astroturf/helpers';
+import * as React from 'react';
 
 // $ExpectType StyledFunction<"a", {}, never>
 styled.a;


### PR DESCRIPTION
supersedes #75 

At the moment the `styled` support is half-baked because we've no shouldForwardProps support, but i don't want to bloat the runtime right now. This is primarily for the css prop case, where we don't need to handle whitelisting