### PR TITLE
fix: 🐛 add virtual css timestamps to webpack compilation

### DIFF
--- a/src/memory-fs.js
+++ b/src/memory-fs.js
@@ -79,6 +79,8 @@ class MemoryFs {
     });
   };
 
+  getPaths = () => this.paths;
+
   exists = (p, cb) => cb(this.existsSync(p));
 
   existsSync = p => this.paths.has(path.normalize(p));

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -45,7 +45,9 @@ export function runLoader(src, options, filename = 'MyStyleFile.js') {
       resourcePath: filename,
       request: `babel-loader!css-literal-loader!${filename}`,
       _compiler: {},
-      _compilation: {},
+      _compilation: {
+        fileTimestamps: new Map(),
+      },
       _module: {},
       resolve(request, cb) {
         cb(null, relative(dirname(filename), request));


### PR DESCRIPTION
When webpack is run in watch mode, the system determines if a given module should be rebuilt by checking the modified timestamp of it's dependencies inside `needRebuild`

https://github.com/webpack/webpack/blob/v4.36.1/lib/NormalModule.js#L522

It was discovered during debugging that for the virtual css modules in astroturf, these timestamps are always undefined in the passed `fileTimestamps` map object.

The effect/bug that this causes is that any astroturf dependant file will always be recompiled, and _any_ change to a file will cause all astroturf dependant files to be be recompiled. This impacts performance on large projects, for example in storybook where there may be many components that could be reloaded by a single change.

To understand why these files are not in the `fileTimestamps` map, we follow the trail of invocation in webpack and find that during watch mode, this map is passed to the compilation object (via the compiler) as a result of the watch callback:

https://github.com/webpack/webpack/blob/v4.36.1/lib/Watching.js#L134

By default this map of `{ [file]: timestamp }` is gathered from the watcher directly:

https://github.com/webpack/webpack/blob/v4.36.1/lib/node/NodeWatchFileSystem.js#L54

And not via the webpack filesystem, which is what astroturf proxies to achieve a virtual file system.

Unfortunately using the same technique to pass a filesystem further into the watcher (by default watchpack) is unlikely to be accepted:

https://github.com/webpack/watchpack/issues/95

This PR addresses this issue by manually updating the `fileTimestamps` map with the virtual css modules after they have been added to the in memory file system directly in the astroturf loader.

In my testing, this has been a fairly harmless and safe fix in order to achieve the desired performance improvement.