### PR TITLE
fix: 🐛 update webpack timestamps on loader file emit

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server"
+    "start": "NODE_DEBUG=astroturf* webpack-dev-server"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.2",

--- a/example/src/ComposedButton.js
+++ b/example/src/ComposedButton.js
@@ -1,0 +1,11 @@
+import styled from 'astroturf'; // eslint-disable-line import/no-extraneous-dependencies
+
+import Button from './Button';
+
+/**
+ * This component demonstrates that the `border-radius` css property takes
+ * precedence over the underlying `<Button/>` css property.
+ */
+export default styled(Button)`
+  border-radius: 10px;
+`;

--- a/example/src/client.js
+++ b/example/src/client.js
@@ -1,10 +1,11 @@
+import { css } from 'astroturf'; // eslint-disable-line import/no-extraneous-dependencies
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { css } from 'astroturf'; // eslint-disable-line import/no-extraneous-dependencies
-
-// import 'bootstrap/scss/bootstrap-reboot.scss';
 
 import Button from './Button';
+import ComposedButton from './ComposedButton';
+
+// import 'bootstrap/scss/bootstrap-reboot.scss';
 
 const _ = css`
   html,
@@ -21,6 +22,7 @@ function App() {
       <Button theme="secondary" bold size={2}>
         Big bold button
       </Button>
+      <ComposedButton theme="primary">Composed Button</ComposedButton>
     </div>
   );
 }

--- a/src/loader.js
+++ b/src/loader.js
@@ -244,7 +244,8 @@ module.exports = function loader(content, map, meta) {
     await Promise.all(dependencies);
 
     styles.forEach(style => {
-      emitVirtualFile(style.absoluteFilePath, style.value);
+      const mtime = emitVirtualFile(style.absoluteFilePath, style.value);
+      compilation.fileTimestamps.set(style.absoluteFilePath, +mtime);
     });
 
     return replaceStyleTemplates(content, changeset);

--- a/src/memory-fs.js
+++ b/src/memory-fs.js
@@ -65,6 +65,8 @@ class MemoryFs {
         )} [${hash}]`,
       );
 
+    const mtime = keepTime ? existing.mtime : new Date();
+
     this.paths.set(p, {
       hash,
       contents: Buffer.isBuffer(data) ? data : Buffer.from(data),
@@ -72,11 +74,10 @@ class MemoryFs {
       birthtime: existing ? existing.birthtime : new Date(),
       ctime: existing ? existing.ctime : new Date(),
       atime: existing ? existing.atime : new Date(),
-      mtime:
-        !updateMtime && existing && existing.hash === hash
-          ? existing.mtime
-          : new Date(),
+      mtime,
     });
+
+    return mtime;
   };
 
   getPaths = () => this.paths;


### PR DESCRIPTION
Due to an oversight in #381 webpack can receive stale timestamps for
virtual css files that need rebuilding. This corrects the issue by
reviving a previous attempt at a fix to be used in conjunction with the
current fix.

Just to clarify that in the end we need to set these timestamps in both locations:
1. In the watch hook before compilation, this ensures that for all files that we _haven't_ changed, webpack will not try to recompile them.
2. After we have updated the virtual css to essential mark these new changes as dirty, otherwise the timestamps for these files are used from step 1, and are therefore out of date.

I added a second component to the example, and added the debugging to the `yarn start` so that I could more accurately test this within the current project.