### PR TITLE
fix: pass correct object to resolve

### DIFF
--- a/src/utils/buildTaggedTemplate.js
+++ b/src/utils/buildTaggedTemplate.js
@@ -14,7 +14,7 @@ const rUnit = new RegExp(`^(${cssUnits.join('|')})(;|,|\n| |\\))`);
 
 function defaultResolveDependency({ request }, localStyle) {
   const source = resolve.sync(request, {
-    baseDir: dirname(localStyle.absoluteFilePath),
+    basedir: dirname(localStyle.absoluteFilePath),
   });
 
   return { source };


### PR DESCRIPTION
`basedir` should not be camelCased https://github.com/browserify/resolve#resolvesyncid-opts