### PR TITLE
Fix Button example in css prop section

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ function Button({ variant, children }) {
         }
       `}
     >
-     {children}
+      {children}
     </button>
   );
 }

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ function Button({ variant, children }) {
         }
       `}
     >
-      children
+     {children}
     </button>
   );
 }


### PR DESCRIPTION
In the css prop section, the `Button` component would always display the string "children" while I guess the intended behavior is to display the `children` props which can either be a string or a react element