### PR TITLE
Use babel to transform js

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,3 @@
-import generate from '@babel/generator';
 import { visitors } from '@babel/traverse';
 import { stripIndent } from 'common-tags';
 import { outputFileSync } from 'fs-extra';
@@ -17,7 +16,6 @@ export default function plugin() {
       if (!file.has(STYLES)) {
         file.set(STYLES, {
           id: 0,
-          changeset: [],
           styles: new Map(),
         });
       }
@@ -29,7 +27,7 @@ export default function plugin() {
 
     post(file) {
       const { opts } = this;
-      let { styles, changeset } = file.get(STYLES);
+      let { styles } = file.get(STYLES);
       const importNodes = file.get(IMPORTS);
 
       importNodes.forEach((path) => {
@@ -39,25 +37,12 @@ export default function plugin() {
 
         if (!decl) return;
 
-        const { start, end } = decl.node;
-
         path.remove();
-
-        if (opts.generateInterpolations)
-          changeset.push({
-            start,
-            end,
-            // if the path is just a removed specifier we need to regenerate
-            // the import statement otherwise we remove the entire declaration
-            code: !path.isImportDeclaration() ? generate(decl.node).code : '',
-          });
       });
 
       styles = Array.from(styles.values());
 
-      changeset = changeset.concat(styles);
-
-      file.metadata.astroturf = { styles, changeset };
+      file.metadata.astroturf = { styles };
 
       if (opts.writeFiles !== false) {
         styles.forEach(({ absoluteFilePath, value }) => {

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -4,21 +4,23 @@ import { transformSync } from '@babel/core';
 
 import plugin from './plugin';
 
-export default function traverse(source, filename, opts) {
+export default function traverse(source, map, filename, opts) {
   const extname = path.extname(filename);
 
   return transformSync(source, {
     filename,
     babelrc: false,
-    code: false,
+    code: true,
     ast: false,
     plugins: [[plugin, opts]],
+    inputSourceMap: map || undefined,
+    sourceMaps: true,
     parserOpts: {
       allowImportExportEverywhere: true,
       allowReturnOutsideFunction: true,
       allowSuperOutsideMethod: true,
       sourceType: 'unambiguous',
-      sourceFilename: true,
+      filenameRelative: filename,
 
       plugins: [
         'jsx',

--- a/test/__file_snapshots__/integration-js.js
+++ b/test/__file_snapshots__/integration-js.js
@@ -279,13 +279,10 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(react__WEBPACK_IMPORTED_MODULE_1__);
 /* harmony import */ var widget__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! widget */ "./test/integration/shared/widget/index.js");
 /* harmony import */ var _Button__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./Button */ "./test/integration/Button.js");
+/** @jsxFrag _f **/
+
 /** @jsx _j **/
 
-/** @jsxFrag _f **/
-const {
-  jsx: _j,
-  F: _f
-} = __webpack_require__(/*! astroturf */ "./src/runtime/styled.js");
 
 
 
@@ -309,10 +306,10 @@ const FancierBox = /*#__PURE__*/astroturf__WEBPACK_IMPORTED_MODULE_0___default()
   vars: []
 });
 function MyComponent() {
-  return _j(_f, null, _j("div", {
+  return Object(astroturf__WEBPACK_IMPORTED_MODULE_0__["jsx"])(astroturf__WEBPACK_IMPORTED_MODULE_0__["F"], null, Object(astroturf__WEBPACK_IMPORTED_MODULE_0__["jsx"])("div", {
     foo: true,
     css: [__webpack_require__(/*! ./main-CssProp1_div.css */ "./test/integration/main-CssProp1_div.css"), []]
-  }, _j("div", null, "hey "), _j("span", {
+  }, Object(astroturf__WEBPACK_IMPORTED_MODULE_0__["jsx"])("div", null, "hey "), Object(astroturf__WEBPACK_IMPORTED_MODULE_0__["jsx"])("span", {
     css: [__webpack_require__(/*! ./main-CssProp2_span.css */ "./test/integration/main-CssProp2_span.css"), []]
   }, "yo")));
 }

--- a/test/__file_snapshots__/loader__css-prop.js
+++ b/test/__file_snapshots__/loader__css-prop.js
@@ -1,8 +1,8 @@
-/** @jsx _j **/
 /** @jsxFrag _f **/
 
-const { jsx: _j, F: _f } = require("astroturf");
-
+/** @jsx _j **/
+import { F as _f } from "astroturf";
+import { jsx as _j } from "astroturf";
 import React from "react";
 
 function Button() {
@@ -14,6 +14,7 @@ function Button2() {
 }
 
 const color = "orange";
+
 function Button3() {
   return (
     <>

--- a/test/__file_snapshots__/loader__element-shorthand.js
+++ b/test/__file_snapshots__/loader__element-shorthand.js
@@ -1,7 +1,5 @@
 import styled from "astroturf";
-
 const SIZE = 75;
-
 const FancyBox = /*#__PURE__*/ styled("div", null, {
   displayName: "FancyBox",
   styles: require("./element-shorthand-FancyBox.css"),

--- a/test/__file_snapshots__/loader__multiple-components.js
+++ b/test/__file_snapshots__/loader__multiple-components.js
@@ -1,15 +1,12 @@
 import styled from "astroturf";
+const SIZE = 75; // prettier-ignore
 
-const SIZE = 75;
-
-// prettier-ignore
-const FancyBox = /*#__PURE__*/styled('div', null, {
+const FancyBox = /*#__PURE__*/ styled("div", null, {
   displayName: "FancyBox",
   styles: require("./multiple-components-FancyBox.css"),
   attrs: null,
-  vars: []
+  vars: [],
 });
-
 const FancyHeader = /*#__PURE__*/ styled("h2", null, {
   displayName: "FancyHeader",
   styles: require("./multiple-components-FancyHeader.css"),

--- a/test/__file_snapshots__/loader__pass-options.js
+++ b/test/__file_snapshots__/loader__pass-options.js
@@ -1,19 +1,19 @@
 import styled from "astroturf";
+const SIZE = 75; // prettier-ignore
 
-const SIZE = 75;
-
-// prettier-ignore
-const FancyBox = /*#__PURE__*/styled('div', {
-  someOption: true
-}, {
-  displayName: "FancyBox",
-  styles: require("./pass-options-FancyBox.css"),
-  attrs: null,
-  vars: []
-});
-
+const FancyBox = /*#__PURE__*/ styled(
+  "div",
+  {
+    someOption: true,
+  },
+  {
+    displayName: "FancyBox",
+    styles: require("./pass-options-FancyBox.css"),
+    attrs: null,
+    vars: [],
+  }
+);
 const options = {};
-
 const FancierBox = /*#__PURE__*/ styled(FancyBox, options, {
   displayName: "FancierBox",
   styles: require("./pass-options-FancierBox.css"),

--- a/test/__file_snapshots__/loader__styled-global.js
+++ b/test/__file_snapshots__/loader__styled-global.js
@@ -5,7 +5,6 @@ const FancyBox = /*#__PURE__*/s('div', null, {
   attrs: null,
   vars: []
 });
-
 const FancierBox = /*#__PURE__*/ s(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-global-FancierBox.css"),

--- a/test/__file_snapshots__/loader__styled-interpolations.js
+++ b/test/__file_snapshots__/loader__styled-interpolations.js
@@ -10,14 +10,12 @@ const FancyBox = /*#__PURE__*/ styled("div", null, {
   attrs: null,
   vars: [],
 });
-
 const FancierBox = /*#__PURE__*/ styled("div", null, {
   displayName: "FancierBox",
   styles: require("./styled-interpolations-FancierBox.css"),
   attrs: null,
   vars: [],
 });
-
 const Button = /*#__PURE__*/ styled(Button, null, {
   displayName: "Button",
   styles: require("./styled-interpolations-Button.css"),

--- a/test/__file_snapshots__/loader__styled-tag.js
+++ b/test/__file_snapshots__/loader__styled-tag.js
@@ -1,13 +1,11 @@
-import s from "astroturf";
+import s from 'astroturf'; // prettier-ignore
 
-// prettier-ignore
-const FancyBox = /*#__PURE__*/s('div', null, {
+const FancyBox = /*#__PURE__*/ s("div", null, {
   displayName: "FancyBox",
   styles: require("./styled-tag-FancyBox.css"),
   attrs: null,
-  vars: []
+  vars: [],
 });
-
 const FancierBox = /*#__PURE__*/ s(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-tag-FancierBox.css"),

--- a/test/__file_snapshots__/loader__styled.js
+++ b/test/__file_snapshots__/loader__styled.js
@@ -1,15 +1,12 @@
 import styled from "astroturf";
+const SIZE = 75; // prettier-ignore
 
-const SIZE = 75;
-
-// prettier-ignore
-const FancyBox = /*#__PURE__*/styled('div', null, {
+const FancyBox = /*#__PURE__*/ styled("div", null, {
   displayName: "FancyBox",
   styles: require("./styled-FancyBox.css"),
   attrs: null,
-  vars: []
+  vars: [],
 });
-
 const FancierBox = /*#__PURE__*/ styled(FancyBox, null, {
   displayName: "FancierBox",
   styles: require("./styled-FancierBox.css"),

--- a/test/__file_snapshots__/loader__typescript.tsx
+++ b/test/__file_snapshots__/loader__typescript.tsx
@@ -1,10 +1,10 @@
-/** @jsx _j **/
 /** @jsxFrag _f **/
 
-const { jsx: _j, F: _f } = require("astroturf");
+/** @jsx _j **/
+import { F as _f } from "astroturf";
+import { jsx as _j } from "astroturf";
 import styled from "astroturf";
 import React from "react";
-
 const SIZE = 75;
 
 const styles = require("./typescript-styles.css");
@@ -14,7 +14,11 @@ interface PropsType {
   name: string;
 }
 
-function someMath<T extends { x: number }>(obj: T): T {
+function someMath<
+  T extends {
+    x: number;
+  }
+>(obj: T): T {
   console.log(Math.abs(obj.x));
   return obj as T;
 }

--- a/test/__file_snapshots__/loader__with-props.js
+++ b/test/__file_snapshots__/loader__with-props.js
@@ -1,12 +1,10 @@
 import { styled } from "astroturf";
-
 const RedPasswordInput = /*#__PURE__*/ styled("input", null, {
   displayName: "RedPasswordInput",
   styles: require("./with-props-RedPasswordInput.css"),
   attrs: (props) => ({ ...props, type: "password" }),
   vars: [],
 });
-
 const RedPasswordInput2 = /*#__PURE__*/ styled("input", null, {
   displayName: "RedPasswordInput2",
   styles: require("./with-props-RedPasswordInput2.css"),

--- a/test/__file_snapshots__/plugin__css-prop.js
+++ b/test/__file_snapshots__/plugin__css-prop.js
@@ -1,8 +1,8 @@
 /** @jsxFrag _f **/
 
 /** @jsx _j **/
-import { F as _f2 } from "astroturf";
-import { jsx as _j2 } from "astroturf";
+import { F as _f } from "astroturf";
+import { jsx as _j } from "astroturf";
 import React from "react";
 
 function Button() {

--- a/test/styled.test.js
+++ b/test/styled.test.js
@@ -54,7 +54,6 @@ describe('styled', () => {
     expect(code).toEqual(
       format`
         import { styled } from 'astroturf';
-
         const ButtonBase = /*#__PURE__*/ styled('button', null, {
           displayName: \"ButtonBase\",
           styles: require(\"./MyStyleFile-ButtonBase.css\"),


### PR DESCRIPTION
Right now replacement happens manually and source map is not created, so line numbers are shifted in js. It's a bit annoying. And I'm not sure why `replaceStyleTemplates` was needed at all. Can you explain please, if it really is needed?