### PR TITLE
Generate js sourcemaps using magic-string

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "fs-extra": "^9.0.0",
     "loader-utils": "^2.0.0",
     "lodash": "^4.17.15",
+    "magic-string": "^0.25.7",
     "memory-fs": "^0.5.0",
     "postcss-atroot": "^0.1.3",
     "postcss-loader": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7258,6 +7258,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+magic-string@^0.25.7:
+  version "0.25.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -9947,6 +9954,11 @@ source-map@^0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 spdx-correct@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
As [suggested](https://github.com/4Catalyzer/astroturf/pull/577#issuecomment-606028521). `magic-string` is pretty cool. If this PR is ok, I'd like to try to map CSS back to JS using `magic-string` again.

Also I'm not sure if tests are needed for source map generation. What do you think?