### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ If you want the simplest, most bare-bones setup you can use the included `css-lo
         test: /\.tsx?$/,
         use: ['ts-loader', 'astroturf/loader'],
       },
-    ];
+    ],
   }
 }
 ```


### PR DESCRIPTION
I fixed typo in an object of webpack config example.