### PR TITLE
feat!: use raw string for  css doesn't need to be double escaped

### DIFF
--- a/src/utils/buildTaggedTemplate.ts
+++ b/src/utils/buildTaggedTemplate.ts
@@ -264,7 +264,7 @@ function buildTemplateImpl(opts: Options, state = { id: 0 }) {
   let lastDynamic: DynamicInterpolation | null = null;
 
   quasi.quasis.forEach((tmplNode, idx) => {
-    const { cooked } = tmplNode.value;
+    const { raw } = tmplNode.value;
     const expr = expressions[idx];
 
     let matches;
@@ -275,14 +275,14 @@ function buildTemplateImpl(opts: Options, state = { id: 0 }) {
       lastDynamic &&
       text.endsWith(`var(--${lastDynamic.id})`) &&
       // eslint-disable-next-line no-cond-assign
-      (matches = cooked!.match(rUnit))
+      (matches = raw.match(rUnit))
     ) {
       const [, unit] = matches;
 
       lastDynamic.unit = unit;
-      text += cooked!.replace(rUnit, '$2');
+      text += raw.replace(rUnit, '$2');
     } else {
-      text += cooked;
+      text += raw;
     }
 
     if (!expr) {

--- a/test/__file_snapshots__/loader__escape-sequences-styles.css
+++ b/test/__file_snapshots__/loader__escape-sequences-styles.css
@@ -1,0 +1,3 @@
+.a\:valid\ class {
+    color: red;
+  }

--- a/test/__file_snapshots__/loader__escape-sequences.js
+++ b/test/__file_snapshots__/loader__escape-sequences.js
@@ -1,0 +1,2 @@
+import _styles from "astroturf/css-loader?inline!./escape-sequences-styles.css";
+const styles = _styles;

--- a/test/__file_snapshots__/plugin__escape-sequences-styles.css
+++ b/test/__file_snapshots__/plugin__escape-sequences-styles.css
@@ -1,0 +1,3 @@
+.a\:valid\ class {
+    color: red;
+  }

--- a/test/__file_snapshots__/plugin__escape-sequences.js
+++ b/test/__file_snapshots__/plugin__escape-sequences.js
@@ -1,0 +1,2 @@
+import _styles from "./escape-sequences-styles.css";
+const styles = _styles;

--- a/test/fixtures/escape-sequences.js
+++ b/test/fixtures/escape-sequences.js
@@ -1,0 +1,9 @@
+import { stylesheet } from 'astroturf';
+
+
+
+const styles = stylesheet`
+  .a\:valid\ class {
+    color: red;
+  }
+`


### PR DESCRIPTION
I think i'm understanding the distinction between these correctly. Is there a downside to doing this?

https://wiki.developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals