### PR TITLE
Process css files with postcss nested

### DIFF
--- a/src/css-loader.ts
+++ b/src/css-loader.ts
@@ -15,9 +15,11 @@ const loader: Loader = function astroturfCssLoader(
   prevMap: any,
   meta?: any,
 ) {
-  const isLast = this.loaderIndex === this.loaders.length - 1;
+  const shouldProcess =
+    this.loaderIndex === this.loaders.length - 1 ||
+    path.extname(this.resourcePath) === '.css';
 
-  if (!isLast) {
+  if (!shouldProcess) {
     return css;
   }
 

--- a/test/__file_snapshots__/default-plugins-chain-js.js
+++ b/test/__file_snapshots__/default-plugins-chain-js.js
@@ -1,0 +1,33 @@
+(window["webpackJsonp"] = window["webpackJsonp"] || []).push([["main"],{
+
+/***/ "./node_modules/mini-css-extract-plugin/dist/loader.js?!./node_modules/css-loader/dist/cjs.js?!./src/css-loader.ts!./test/tag-loader.js!./test/integration/styles/plain-css.css":
+/*!********************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/mini-css-extract-plugin/dist/loader.js??ref--4-0!./node_modules/css-loader/dist/cjs.js??ref--4-1!./src/css-loader.ts!./test/tag-loader.js!./test/integration/styles/plain-css.css ***!
+  \********************************************************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+// extracted by mini-css-extract-plugin
+/* harmony default export */ __webpack_exports__["default"] = ({"btn":"plain-css__btn"});
+
+/***/ }),
+
+/***/ "./test/integration/css-loader-2.js":
+/*!******************************************!*\
+  !*** ./test/integration/css-loader-2.js ***!
+  \******************************************/
+/*! no exports provided */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _src_css_loader_ts_inline_styles_plain_css_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../../src/css-loader.ts?inline!./styles/plain-css.css */ "./node_modules/mini-css-extract-plugin/dist/loader.js?!./node_modules/css-loader/dist/cjs.js?!./src/css-loader.ts!./test/tag-loader.js!./test/integration/styles/plain-css.css");
+ // use the import so it's not removed
+
+console.log(_src_css_loader_ts_inline_styles_plain_css_css__WEBPACK_IMPORTED_MODULE_0__["default"]);
+
+/***/ })
+
+},[["./test/integration/css-loader-2.js","runtime~main"]]]);

--- a/test/__file_snapshots__/default-plugins-chain-styles.css
+++ b/test/__file_snapshots__/default-plugins-chain-styles.css
@@ -1,0 +1,14 @@
+/* tagged! */
+
+.plain-css__btn {
+  color: red;
+}
+
+.plain-css__btn:hover {
+    color: blue;
+  }
+
+html {
+      font-size: 1px;
+    }
+

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -171,7 +171,7 @@ describe('webpack integration', () => {
 });
 
 describe('css-loader', () => {
-  function getConfig(entry) {
+  function getConfig(entry, other) {
     const config = getBaseConfig(entry, {
       extension: '.scss',
     });
@@ -189,7 +189,8 @@ describe('css-loader', () => {
             loader: 'css-loader',
             options: cssModuleOptions,
           },
-        ],
+          other,
+        ].filter(Boolean),
       },
       {
         test: /\.scss$/,
@@ -238,6 +239,27 @@ describe('css-loader', () => {
     );
     expect(assets['main.js'].source()).toMatchFile(
       path.join(__dirname, '__file_snapshots__/default-plugins-js.js'),
+    );
+  });
+
+  it.only('adds default plugins plain css', async () => {
+    const assets = await runWebpack(
+      getConfig('./integration/css-loader-2.js', {
+        loader: require.resolve('./tag-loader'),
+      }),
+    );
+
+    const src = assets['main.css'].source();
+    expect(src).not.toContain('&:hover');
+
+    expect(src).toMatchFile(
+      path.join(
+        __dirname,
+        '__file_snapshots__/default-plugins-chain-styles.css',
+      ),
+    );
+    expect(assets['main.js'].source()).toMatchFile(
+      path.join(__dirname, '__file_snapshots__/default-plugins-chain-js.js'),
     );
   });
 });

--- a/test/tag-loader.js
+++ b/test/tag-loader.js
@@ -1,0 +1,1 @@
+module.exports = (src) => `/* tagged! */\n\n${src}`;


### PR DESCRIPTION
I've found it annoying to have to setup postcss nested when using normal css files. The `isLast` check isn't enough usually b/c postcss-loader is often used ahead of css-loader for utility prefixing and what-not. This does slightly more work than needed in cases where nesting is already added but in practice i don't think it'll matter