### PR TITLE
Fix #140

### DIFF
--- a/src/traverse.js
+++ b/src/traverse.js
@@ -26,7 +26,7 @@ export default function traverse(source, filename, opts) {
         extname === '.ts' || extname === '.tsx' ? 'typescript' : 'flow',
         'doExpressions',
         'objectRestSpread',
-        ['decorators', { legacy: true }],
+        'decorators-legacy',
         'classProperties',
         'classPrivateProperties',
         'classPrivateMethods',

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -10,6 +10,7 @@ export default function traverse(source, filename, opts) {
   return transformSync(source, {
     filename,
     babelrc: false,
+    configFile: false,
     code: false,
     ast: false,
     plugins: [[plugin, opts]],
@@ -25,7 +26,7 @@ export default function traverse(source, filename, opts) {
         extname === '.ts' || extname === '.tsx' ? 'typescript' : 'flow',
         'doExpressions',
         'objectRestSpread',
-        ['decorators', { decoratorsBeforeExport: true }],
+        ['decorators', { legacy: true }],
         'classProperties',
         'classPrivateProperties',
         'classPrivateMethods',


### PR DESCRIPTION
This just makes decorator syntax parsable and turns off `configFile` (to match `babelrc`) The other idea** is not implemented here and should probably be another PR.

** The other idea was to just have baseline language features enabled (those beyond stage 4) and let babelrc/configFile enable local project exotic syntax.